### PR TITLE
mock 데이터 도메인 설계

### DIFF
--- a/src/main/java/org/leedae/testdata/domain/MockData.java
+++ b/src/main/java/org/leedae/testdata/domain/MockData.java
@@ -1,0 +1,14 @@
+package org.leedae.testdata.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class MockData {
+
+    private String mockDatType;
+    private String mockDataValue;
+}

--- a/src/main/java/org/leedae/testdata/domain/MockData.java
+++ b/src/main/java/org/leedae/testdata/domain/MockData.java
@@ -3,12 +3,13 @@ package org.leedae.testdata.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.leedae.testdata.domain.constant.MockDataType;
 
 @Getter
 @Setter
 @ToString
 public class MockData {
 
-    private String mockDatType;
+    private MockDataType mockDatType;
     private String mockDataValue;
 }


### PR DESCRIPTION
이 작업은 가짜 데이터 중 알고맂므으로 생성하기 적절치 않은 고유명사를 사전식으로 미리 저장해뒀다가 꺼내 쓰기 위해 가짜 데이터 도메인을 설계한다.

This closes #9