### PR TITLE
테스트용: H2, 인메모리DB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ logging:
     org.springframework.web.servlet: debug
 spring:
   application.name : test-data
+  datasource.url: jdbc:h2:mem:testdb
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -15,4 +16,10 @@ spring:
       hibernate:
         format_sql: true
   sql.init.mode: always
+
+---
+
+spring:
+  config.activate.on.profile: test
+  datasource.url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE
 


### PR DESCRIPTION
이 pr은 h2 db를 사용하도록 스프링 부트 프로퍼티를 추가한다.
또한 테스트 프로퍼티를 별도로 설정하여 mysql 호환성 모드로도 h2가 동작할 수 있도록 환경을 준비함.

This closes #42 