### PR TITLE
리얼 MySQL 8.X

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,7 +6,10 @@ logging:
     org.springframework.web.servlet: debug
 spring:
   application.name : test-data
-  datasource.url: jdbc:h2:mem:testdb
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PW}
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -20,6 +23,6 @@ spring:
 ---
 
 spring:
-  config.activate.on.profile: test
+  config.activate.on-profile: test
   datasource.url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE
 

--- a/src/test/java/org/leedae/testdata/TestDataApplicationTests.java
+++ b/src/test/java/org/leedae/testdata/TestDataApplicationTests.java
@@ -2,7 +2,9 @@ package org.leedae.testdata;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class TestDataApplicationTests {
 


### PR DESCRIPTION
이 작업은 부트 앱이 동작할 때 인메모리 DB대신 실제 DB를 바라보도록 스프링 프로퍼티를 수정한다.
다만 그대로 DB 접근 정보를 쓰면 보안에 문제가 되므로, 시스템 환경변수형태로 넣는다.
이 변경 후에도 테스트가 잘 동작하도록 기본 테스트의 프로파일을 수정한다.