### PR TITLE
데이터베이스: DB를 표현할 entity 코드의 작성

### DIFF
--- a/src/main/java/org/leedae/testdata/domain/AuditingFields.java
+++ b/src/main/java/org/leedae/testdata/domain/AuditingFields.java
@@ -1,0 +1,40 @@
+package org.leedae.testdata.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; //생성일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    private String createdBy; // 생성자
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; //수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false)
+    private String modifiedBy; // 수정자
+
+}

--- a/src/main/java/org/leedae/testdata/domain/MockData.java
+++ b/src/main/java/org/leedae/testdata/domain/MockData.java
@@ -1,15 +1,69 @@
 package org.leedae.testdata.domain;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.leedae.testdata.domain.constant.MockDataType;
 
+import java.util.Objects;
+
+/**
+ * 특정 {@link MockDataType} 가짜 데이터 자료형에 대응하는 가짜 데이터.
+ * 알고리즘으로 생성하지 않는 {@link MockDataType} 경우, 이 가짜 데이터를 랜덤으로 뽑아 출력한다.
+ * @author lee
+ */
 @Getter
-@Setter
 @ToString
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"mockDataType", "mockDataValue"})
+})
+@Entity
 public class MockData {
 
-    private MockDataType mockDatType;
-    private String mockDataValue;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Setter @Column(nullable = false) private MockDataType mockDataType;
+
+    @Setter @Column(nullable = false) private String mockDataValue;
+
+
+    protected MockData(){}
+
+    public MockData(MockDataType mockDatType, String mockDataValue) {
+        this.mockDataType = mockDatType;
+        this.mockDataValue = mockDataValue;
+    }
+
+    public static MockData of(MockDataType mockDataType, String mockDataValue){
+        return new MockData(mockDataType,mockDataValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MockData that)) return false;
+
+        if(getId() == null){
+            return Objects.equals(this.getMockDataType(),that.getMockDataType()) &&
+                    Objects.equals(this.getMockDataValue(), that.getMockDataValue());
+
+         }
+
+        return Objects.equals(this.getId(),that.getId());
+
+
+    }
+
+    @Override
+    public int hashCode() {
+        if(getId() == null){
+            return Objects.hash(getMockDataType(), getMockDataValue());
+        }
+
+        return Objects.hash(getId());
+    }
 }

--- a/src/main/java/org/leedae/testdata/domain/SchemaField.java
+++ b/src/main/java/org/leedae/testdata/domain/SchemaField.java
@@ -1,21 +1,97 @@
 package org.leedae.testdata.domain;
 
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.leedae.testdata.domain.constant.MockDataType;
 
-@Getter
-@Setter
-@ToString
-public class SchemaField {
+import java.time.LocalDateTime;
+import java.util.Objects;
 
-    private String fieldName;
-    private MockDataType mockDateType;
-    private Integer fieldOrder;
-    private Integer blankPercent;
+
+/**
+ * 특정 {@link TableSchema}의 단위 필드 정보,
+ * 이 필드들이 모여서 테이블 스키마를 구성한다.
+ *
+ * @author lee
+ */
+@Getter
+@ToString(callSuper = true)
+@Entity
+public class SchemaField extends AuditingFields {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @ManyToOne(optional = false)
+    private TableSchema tableSchema;
+
+    @Setter
+    private @Column(nullable = false) String fieldName;
+    @Setter
+    private @Column(nullable = false) MockDataType mockDataType;
+    @Setter
+    private @Column(nullable = false) Integer fieldOrder;
+    @Setter
+    private @Column(nullable = false) Integer blankPercent;
+
+
+
+    @Setter
     private String typeOptionJson;
+    @Setter
     private String forceValue;
 
+    protected SchemaField() {
+    }
+
+    public SchemaField(String fieldName, MockDataType mockDataType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        this.fieldName = fieldName;
+        this.mockDataType = mockDataType;
+        this.fieldOrder = fieldOrder;
+        this.blankPercent = blankPercent;
+        this.typeOptionJson = typeOptionJson;
+        this.forceValue = forceValue;
+    }
+
+    public static SchemaField of(String fieldName, MockDataType mockDateType, Integer fieldOrder, Integer blankPercent, String typeOptionJson, String forceValue) {
+        return new SchemaField(fieldName, mockDateType, fieldOrder, blankPercent, typeOptionJson, forceValue);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SchemaField that)) return false;
+
+        if (that.getId() == null) {
+            return Objects.equals(this.getTableSchema().getId(), that.getTableSchema().getId()) &&
+                    Objects.equals(this.getMockDataType(), that.getMockDataType()) &&
+                    Objects.equals(this.getFieldName(), that.getFieldName()) &&
+                    Objects.equals(this.getFieldOrder(), that.getFieldOrder()) &&
+                    Objects.equals(this.getBlankPercent(), that.getBlankPercent()) &&
+                    Objects.equals(this.getTypeOptionJson(), that.getTypeOptionJson()) &&
+                    Objects.equals(this.getForceValue(), that.getForceValue());
+        }
+
+        return Objects.equals(this.getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+
+        if (getId() == null) {
+            return Objects.hash(getTableSchema().getId(), getMockDataType(), getFieldName(), getFieldOrder(), getBlankPercent(), getTypeOptionJson(), getForceValue());
+        }
+
+        return Objects.hash(getId());
+
+    }
+
 }
+

--- a/src/main/java/org/leedae/testdata/domain/TableSchema.java
+++ b/src/main/java/org/leedae/testdata/domain/TableSchema.java
@@ -1,18 +1,97 @@
 package org.leedae.testdata.domain;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 
+/**
+ * 단위 테이블 스키마 정보
+ * 식별자({@link #userId})로 특정할 수 있는 회원이 소유한다.
+ *
+ * @author Lee
+ */
 @Getter
 @Setter
-@ToString
-public class TableSchema {
+@ToString(callSuper = true)
+@Entity
+public class TableSchema extends AuditingFields {
 
-    private String schemaName;
-    private String userId;
-    private LocalDateTime exportedAt;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter private String schemaName;
+    @Setter private String userId;
+    @Setter private LocalDateTime exportedAt;
+
+
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final Set<SchemaField> schemaFields = new LinkedHashSet<>();
+
+    protected TableSchema(){}
+
+    public TableSchema(String schemaName, String userId) {
+        this.schemaName = schemaName;
+        this.userId = userId;
+        this.exportedAt = null;
+    }
+
+    public static TableSchema of(String schemaName, String userId){
+        return new TableSchema(schemaName, userId);
+    }
+
+    public void addSchemaField(SchemaField schemaField){
+        schemaFields.add(schemaField);
+        schemaField.setTableSchema(this);
+    }
+
+    public void addSchemaFields(Collection<SchemaField> schemaFields){
+        schemaFields.forEach(this::addSchemaField);
+    }
+
+    public void clearSchemaFields(){
+        schemaFields.clear();
+    }
+
+    public void markExported(){
+        exportedAt = LocalDateTime.now();
+    }
+
+    public boolean isExported(){
+        return exportedAt != null;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TableSchema that)) return false;
+
+        if(getId() == null){
+            return Objects.equals(this.getSchemaName(),that.getSchemaName()) &&
+                    Objects.equals(this.getUserId(), that.getUserId());
+        }
+
+        return Objects.equals(this.getId(),that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        if(getId() == null){
+            return Objects.hash(getSchemaName(), getUserId());
+        }
+
+        return Objects.hash(getId());
+    }
 
 }


### PR DESCRIPTION
이 작업은 도메인을 엔티티 코드로 발전시킨다. 또한 auditing 메타 정보를 쉽게 다루도록 하는 별도의 추상 클래스를 도입한다.

This closes #14 