### PR TITLE
로직 구현: 개인 스키마 정보 읽어들이기

### DIFF
--- a/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
+++ b/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
@@ -1,7 +1,6 @@
 package org.leedae.testdata.controller;
 
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +11,11 @@ import org.leedae.testdata.dto.request.TableSchemaRequest;
 import org.leedae.testdata.dto.response.SchemaFieldResponse;
 import org.leedae.testdata.dto.response.SimpleTableSchemaResponse;
 import org.leedae.testdata.dto.response.TableSchemaResponse;
+import org.leedae.testdata.dto.security.GithubUser;
+import org.leedae.testdata.service.TableSchemaService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +24,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -30,18 +31,20 @@ import java.util.List;
 @Controller
 public class TableSchemaController {
 
+    private final TableSchemaService tableSchemaService;
     private final ObjectMapper mapper;
 
     @GetMapping("/table-schema")
     public String tableSchema(
             @RequestParam(required = false) String schemaName,
-            Model model) {
+            Model model
+    ) {
         var tableSchema = defaultTableSchema(schemaName);
 
-
-        model.addAttribute("tableSchema",tableSchema);
-        model.addAttribute("mockDataTypes",MockDataType.toObjects());
+        model.addAttribute("tableSchema", tableSchema);
+        model.addAttribute("mockDataTypes", MockDataType.toObjects());
         model.addAttribute("fileTypes", Arrays.stream(ExportFileType.values()).toList());
+
         return "table-schema";
     }
 
@@ -58,62 +61,51 @@ public class TableSchemaController {
     }
 
     @GetMapping("/table-schema/my-schemas")
-    public String mySchemas(Model model) {
-        var tableSchemas = mySampleSchemas();
+    public String mySchemas(
+            @AuthenticationPrincipal GithubUser githubUser,
+            Model model
+    ) {
+        List<SimpleTableSchemaResponse> tableSchemas = tableSchemaService.loadMySchemas(githubUser.id())
+                .stream()
+                .map(SimpleTableSchemaResponse::fromDto)
+                .toList();
 
         model.addAttribute("tableSchemas", tableSchemas);
-
-
 
         return "my-schemas";
     }
 
-
-
     @PostMapping("/table-schema/my-schemas/{schemaName}")
-    public String deleteSchema(
-            @PathVariable String schemaName,
-            RedirectAttributes redirectAttrs){
+    public String deleteMySchema(@PathVariable String schemaName) {
         return "redirect:/table-schema/my-schemas";
     }
 
-
     @GetMapping("/table-schema/export")
-    public ResponseEntity<String> exportSchema(TableSchemaExportRequest tableSchemaExportRequest) {
+    public ResponseEntity<String> exportTableSchema(TableSchemaExportRequest tableSchemaExportRequest) {
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION,"attachment; filename=table-schema.txt")
-                .body(json(tableSchemaExportRequest)); //TODO: 나중에 작업 예정
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=table-schema.txt")
+                .body(json(tableSchemaExportRequest)); // TODO: 나중에 데이터 바꿔야 함
     }
 
 
     private TableSchemaResponse defaultTableSchema(String schemaName) {
         return new TableSchemaResponse(
                 schemaName != null ? schemaName : "schema_name",
-                "Lee",
+                "Uno",
                 List.of(
                         new SchemaFieldResponse("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
                         new SchemaFieldResponse("name", MockDataType.NAME, 2, 10, null, null),
                         new SchemaFieldResponse("age", MockDataType.NUMBER, 3, 20, null, null),
                         new SchemaFieldResponse("my_car", MockDataType.CAR, 4, 50, null, null)
-
                 )
-
         );
     }
 
-    private static List<SimpleTableSchemaResponse> mySampleSchemas() {
-        return List.of(
-                new SimpleTableSchemaResponse("schema_name1", "Lee", LocalDate.of(2024, 1, 1).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name2", "Lee", LocalDate.of(2024, 2, 2).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name3", "Lee", LocalDate.of(2024, 3, 3).atStartOfDay())
-        );
-    }
-
-    private String json(Object object){
-        try{
+    private String json(Object object) {
+        try {
             return mapper.writeValueAsString(object);
-        }catch (JsonProcessingException jpe){
+        } catch (JsonProcessingException jpe) {
             throw new RuntimeException(jpe);
         }
     }

--- a/src/main/java/org/leedae/testdata/service/TableSchemaService.java
+++ b/src/main/java/org/leedae/testdata/service/TableSchemaService.java
@@ -1,0 +1,33 @@
+package org.leedae.testdata.service;
+
+import lombok.RequiredArgsConstructor;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.leedae.testdata.repository.TableSchemaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TableSchemaService {
+
+    private final TableSchemaRepository tableSchemaRepository;
+
+
+    @Transactional(readOnly = true)
+    public List<TableSchemaDto> loadMySchemas(String userId) {
+        return loadMySchemas(userId, Pageable.unpaged()).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TableSchemaDto> loadMySchemas(String userId, Pageable pageable) {
+        return tableSchemaRepository.findByUserId(userId, pageable)
+                .map(TableSchemaDto::fromEntity);
+    }
+
+
+}

--- a/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
@@ -1,7 +1,6 @@
 package org.leedae.testdata.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.leedae.testdata.config.SecurityConfig;
@@ -11,9 +10,11 @@ import org.leedae.testdata.dto.request.SchemaFieldRequest;
 import org.leedae.testdata.dto.request.TableSchemaExportRequest;
 import org.leedae.testdata.dto.request.TableSchemaRequest;
 import org.leedae.testdata.dto.security.GithubUser;
+import org.leedae.testdata.service.TableSchemaService;
 import org.leedae.testdata.util.FormDataEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -22,28 +23,31 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("[Controller] - 테이블 스키마 컨트롤러 테스트")
+@DisplayName("[Controller] 테이블 스키마 컨트롤러 테스트")
 @Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(TableSchemaController.class)
-public record TableSchemaControllerTest(
-        @Autowired MockMvc mvc,
-        @Autowired FormDataEncoder formDataEncoder,
-        @Autowired ObjectMapper mapper
+class TableSchemaControllerTest {
 
-) {
+    @Autowired private MockMvc mvc;
+    @Autowired private FormDataEncoder formDataEncoder;
+    @Autowired private ObjectMapper mapper;
+
+    @MockBean private TableSchemaService tableSchemaService;
 
     @DisplayName("[GET] 테이블 스키마 조회, 비로그인 최초 진입 (정상)")
     @Test
     void givenNothing_whenRequesting_thenShowsTableSchemaView() throws Exception {
-        //Given
+        // Given
 
-        //When & Then
+        // When & Then
         mvc.perform(get("/table-schema"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
@@ -57,7 +61,7 @@ public record TableSchemaControllerTest(
     @Test
     void givenAuthenticatedUserAndSchemaName_whenRequesting_thenShowsTableSchemaView() throws Exception {
         // Given
-        var githubUser = new GithubUser("test-id", "test-name", "test@gmail.com");
+        var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         var schemaName = "test_schema";
 
         // When & Then
@@ -79,9 +83,8 @@ public record TableSchemaControllerTest(
     @DisplayName("[POST] 테이블 스키마 생성, 변경 (정상)")
     @Test
     void givenTableSchemaRequest_whenCreatingOrUpdating_thenRedirectsToTableSchemaView() throws Exception {
-        //Given
-        var githubUser = new GithubUser("test-id", "test-name", "test@gmail.com");
-
+        // Given
+        var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         TableSchemaRequest request = TableSchemaRequest.of(
                 "test_schema",
                 "홍길동",
@@ -90,91 +93,91 @@ public record TableSchemaControllerTest(
                         SchemaFieldRequest.of("name", MockDataType.NAME, 2, 10, null, null),
                         SchemaFieldRequest.of("age", MockDataType.NUMBER, 3, 20, null, null)
                 )
-
         );
 
-        //When & Then
+        // When & Then
         mvc.perform(
                         post("/table-schema")
                                 .content(formDataEncoder.encode(request))
                                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                                 .with(csrf())
                                 .with(oauth2Login().oauth2User(githubUser))
-
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attribute("tableSchemaRequest", request))
                 .andExpect(redirectedUrl("/table-schema"));
     }
 
+    @DisplayName("[GET] 내 스키마 목록 조회 (비로그인)")
+    @Test
+    void givenNothing_whenRequesting_thenRedirectsToLogin() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/table-schema/my-schemas"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/oauth2/authorization/github"));
+        then(tableSchemaService).shouldHaveNoInteractions();
+    }
+
     @DisplayName("[GET] 내 스키마 목록 조회 (정상)")
     @Test
-    void givenAuthenticatedUser_whenRequesting_thenShowsMySchemasView() throws Exception {
-        //Given
-        var githubUser = new GithubUser("test-id", "test-name", "test@gmail.com");
+    void givenAuthenticatedUser_whenRequesting_thenShowsMySchemaView() throws Exception {
+        // Given
+        var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
+        given(tableSchemaService.loadMySchemas(githubUser.id())).willReturn(List.of());
 
-        //When & Then
+        // When & Then
         mvc.perform(
                         get("/table-schema/my-schemas")
                                 .with(oauth2Login().oauth2User(githubUser))
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(model().attributeExists("tableSchemas"))
+                .andExpect(model().attribute("tableSchemas", List.of()))
                 .andExpect(view().name("my-schemas"));
+        then(tableSchemaService).should().loadMySchemas(githubUser.id());
     }
-
-    @DisplayName("[GET] 내 스키마 목록 조회 (비로그인)")
-    @Test
-    void givenNothing_whenRequesting_thenReturnsToLogin() throws Exception {
-        //Given
-
-
-        //When & Then
-        mvc.perform(get("/table-schema/my-schemas"))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("**/oauth2/authorization/github"));
-    }
-
 
     @DisplayName("[POST] 내 스키마 삭제 (정상)")
     @Test
-    void givenAuthenticatedUserAndSchemaName_whenDeleting_thenRedirectsToMySchemasView() throws Exception {
-        //Given
+    void givenAuthenticatedUserAndSchemaName_whenDeleting_thenRedirectsToTableSchemaView() throws Exception {
+        // Given
+        var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         String schemaName = "test_schema";
 
-        //When & Then
+        // When & Then
         mvc.perform(
                         post("/table-schema/my-schemas/{schemaName}", schemaName)
                                 .with(csrf())
+                                .with(oauth2Login().oauth2User(githubUser))
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/table-schema/my-schemas"));
     }
 
-    @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상)  ")
+    @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상)")
     @Test
     void givenTableSchema_whenDownloading_thenReturnsFile() throws Exception {
-        //Given
+        // Given
         TableSchemaExportRequest request = TableSchemaExportRequest.of(
-                "test_schema",
-                10,
+                "test",
+                77,
                 ExportFileType.JSON,
                 List.of(
                         SchemaFieldRequest.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
-                        SchemaFieldRequest.of("name", MockDataType.NAME, 2, 10, "option", "well"),
+                        SchemaFieldRequest.of("name", MockDataType.STRING, 1, 0, "option", "well"),
                         SchemaFieldRequest.of("age", MockDataType.NUMBER, 3, 20, null, null)
                 )
         );
         String queryParam = formDataEncoder.encode(request, false);
 
-        //When & Then
+        // When & Then
         mvc.perform(get("/table-schema/export?" + queryParam))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
                 .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=table-schema.txt"))
-                .andExpect(content().json(mapper.writeValueAsString(request))); //TODO: 나중에 데이터 바꿔야 함
+                .andExpect(content().json(mapper.writeValueAsString(request))); // TODO: 나중에 데이터 바꿔야 함
     }
-
 
 }

--- a/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
@@ -1,0 +1,59 @@
+package org.leedae.testdata.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.leedae.testdata.domain.TableSchema;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.leedae.testdata.repository.TableSchemaRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@DisplayName("[Service] 테이블 스키마 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TableSchemaServiceTest {
+
+    @InjectMocks private TableSchemaService sut;
+
+    @Mock private TableSchemaRepository tableSchemaRepository;
+
+
+    @DisplayName("사용자 ID가 주어지면, 테이블 스키마 목록을 반환한다.")
+    @Test
+    void givenUserId_whenLoadingMySchemas_thenReturnsTableSchemaList() {
+        // Given
+        String userId = "userId";
+        given(tableSchemaRepository.findByUserId(userId, Pageable.unpaged())).willReturn(new PageImpl<>(List.of(
+                TableSchema.of("table1", userId),
+                TableSchema.of("table2", userId),
+                TableSchema.of("table3", userId)
+        )));
+
+        // When
+        List<TableSchemaDto> result = sut.loadMySchemas(userId);
+
+        // Then
+        assertThat(result)
+                .hasSize(3)
+                .extracting("schemaName")
+                .containsExactly("table1", "table2", "table3");
+        then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
+    }
+
+}


### PR DESCRIPTION
이 작업은 내 스키마 목록을 읽어들이는 실제 비즈니스 로직을 구현하여 컨트롤러 api에 기능으로 연결짓는다.

This closes #29 