### PR TITLE
로직 구현: 개인 스키마 정보 읽어들이기 2

### DIFF
--- a/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
+++ b/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
@@ -36,10 +36,13 @@ public class TableSchemaController {
 
     @GetMapping("/table-schema")
     public String tableSchema(
+            @AuthenticationPrincipal GithubUser githubUser,
             @RequestParam(required = false) String schemaName,
             Model model
     ) {
-        var tableSchema = defaultTableSchema(schemaName);
+        TableSchemaResponse tableSchema = (githubUser != null && schemaName != null) ?
+                TableSchemaResponse.fromDto(tableSchemaService.loadMySchema(githubUser.id(), schemaName)) :
+                defaultTableSchema(schemaName);
 
         model.addAttribute("tableSchema", tableSchema);
         model.addAttribute("mockDataTypes", MockDataType.toObjects());
@@ -47,8 +50,6 @@ public class TableSchemaController {
 
         return "table-schema";
     }
-
-
 
     @PostMapping("/table-schema")
     public String createOrUpdateTableSchema(

--- a/src/main/java/org/leedae/testdata/service/TableSchemaService.java
+++ b/src/main/java/org/leedae/testdata/service/TableSchemaService.java
@@ -1,5 +1,6 @@
 package org.leedae.testdata.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.leedae.testdata.dto.TableSchemaDto;
 import org.leedae.testdata.repository.TableSchemaRepository;
@@ -29,5 +30,11 @@ public class TableSchemaService {
                 .map(TableSchemaDto::fromEntity);
     }
 
+    @Transactional(readOnly = true)
+    public TableSchemaDto loadMySchema(String userId, String schemaName) {
+        return tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)
+                .map(TableSchemaDto::fromEntity)
+                .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
+    }
 
 }

--- a/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.leedae.testdata.config.SecurityConfig;
 import org.leedae.testdata.domain.constant.ExportFileType;
 import org.leedae.testdata.domain.constant.MockDataType;
+import org.leedae.testdata.dto.TableSchemaDto;
 import org.leedae.testdata.dto.request.SchemaFieldRequest;
 import org.leedae.testdata.dto.request.TableSchemaExportRequest;
 import org.leedae.testdata.dto.request.TableSchemaRequest;
@@ -21,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
@@ -55,6 +57,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("mockDataTypes"))
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(view().name("table-schema"));
+        then(tableSchemaService).shouldHaveNoInteractions();
     }
 
     @DisplayName("[GET] 테이블 스키마 조회, 로그인 + 특정 테이블 스키마 (정상)")
@@ -63,6 +66,7 @@ class TableSchemaControllerTest {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         var schemaName = "test_schema";
+        given(tableSchemaService.loadMySchema(githubUser.id(), schemaName)).willReturn(TableSchemaDto.of(schemaName, githubUser.id(), null, Set.of()));
 
         // When & Then
         mvc.perform(
@@ -78,6 +82,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(content().string(containsString(schemaName))) // html 전체 검사하므로 정확하지 않은 테스트 방식
                 .andExpect(view().name("table-schema"));
+        then(tableSchemaService).should().loadMySchema(githubUser.id(), schemaName);
     }
 
     @DisplayName("[POST] 테이블 스키마 생성, 변경 (정상)")

--- a/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
@@ -10,8 +10,6 @@ import org.leedae.testdata.repository.TableSchemaRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -20,7 +18,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -54,6 +51,43 @@ class TableSchemaServiceTest {
                 .extracting("schemaName")
                 .containsExactly("table1", "table2", "table3");
         then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름이 주어지면, 테이블 스키마를 반환한다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingMySchema_thenReturnsTableSchema() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        TableSchema tableSchema = TableSchema.of(schemaName, userId);
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)).willReturn(Optional.of(tableSchema));
+
+        // When
+        TableSchemaDto result = sut.loadMySchema(userId, schemaName);
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("schemaName", schemaName)
+                .hasFieldOrPropertyWithValue("userId", userId);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름에 대응하는 테이블 스키마가 없으면, 예외를 던진다.")
+    @Test
+    void givenUserIdAndSchemaName_whenLoadingNonexistentMySchema_thenThrowsException() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        given(tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.loadMySchema(userId, schemaName));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName);
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
     }
 
 }


### PR DESCRIPTION
이 pr은 지난 #61 작업에 이어서 회원 스키마 테이블 단건 조회를 구현하고 컨트롤러와 연결한다.

This closes #29 