### PR TITLE
로직 구현: 개인 스키마 정보 저장하기

### DIFF
--- a/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
+++ b/src/main/java/org/leedae/testdata/controller/TableSchemaController.java
@@ -53,11 +53,14 @@ public class TableSchemaController {
 
     @PostMapping("/table-schema")
     public String createOrUpdateTableSchema(
+            @AuthenticationPrincipal GithubUser githubUser,
             TableSchemaRequest tableSchemaRequest,
             RedirectAttributes redirectAttrs
     ) {
+        tableSchemaService.saveSchema(tableSchemaRequest.toDto(githubUser.id()));
         redirectAttrs.addFlashAttribute("tableSchemaRequest", tableSchemaRequest);
-
+        //addFlashAttribute는 저장된 정보를 그대로 보여줘야 하므로 사용했음.
+        
         return "redirect:/table-schema";
     }
 

--- a/src/main/java/org/leedae/testdata/dto/request/TableSchemaRequest.java
+++ b/src/main/java/org/leedae/testdata/dto/request/TableSchemaRequest.java
@@ -14,11 +14,11 @@ import java.util.stream.Collectors;
 @Data
 public class TableSchemaRequest {
     private String schemaName;
-    private String userId;
     private List<SchemaFieldRequest> schemaFields;
 
 
-    public TableSchemaDto toDto(){
+    //기존엔 TableSchemaRequest 필드에 userId도 포함이 되었지만, 외부에서 따로 주입해줘야 하므로 메서드 인자로 따로 받기
+    public TableSchemaDto toDto(String userId){
         return TableSchemaDto.of(
                 schemaName,
                 userId,

--- a/src/main/java/org/leedae/testdata/service/TableSchemaService.java
+++ b/src/main/java/org/leedae/testdata/service/TableSchemaService.java
@@ -37,4 +37,11 @@ public class TableSchemaService {
                 .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
     }
 
+    public void saveSchema(TableSchemaDto dto) {
+        tableSchemaRepository.save(dto.createEntity());
+    }
+
+
+
+
 }

--- a/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
@@ -25,8 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -92,13 +91,13 @@ class TableSchemaControllerTest {
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         TableSchemaRequest request = TableSchemaRequest.of(
                 "test_schema",
-                "홍길동",
                 List.of(
                         SchemaFieldRequest.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
                         SchemaFieldRequest.of("name", MockDataType.NAME, 2, 10, null, null),
                         SchemaFieldRequest.of("age", MockDataType.NUMBER, 3, 20, null, null)
                 )
         );
+       willDoNothing().given(tableSchemaService).saveSchema(request.toDto(githubUser.id()));
 
         // When & Then
         mvc.perform(
@@ -111,6 +110,7 @@ class TableSchemaControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attribute("tableSchemaRequest", request))
                 .andExpect(redirectedUrl("/table-schema"));
+        then(tableSchemaService).should().saveSchema(request.toDto(githubUser.id()));
     }
 
     @DisplayName("[GET] 내 스키마 목록 조회 (비로그인)")

--- a/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/org/leedae/testdata/service/TableSchemaServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -89,5 +90,22 @@ class TableSchemaServiceTest {
                 .hasMessage("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName);
         then(tableSchemaRepository).should().findByUserIdAndSchemaName(userId, schemaName);
     }
+
+    @DisplayName("테이블 스키마 정보가 주어지면, 테이블 스키마를 추가한다.")
+    @Test
+    void givenTableSchema_whenInserting_thenCreatesTableSchema(){
+        //Given
+        TableSchemaDto dto = TableSchemaDto.of("table1", "userId", null, Set.of());
+        given(tableSchemaRepository.save(dto.createEntity())).willReturn(null);
+        //When
+        sut.saveSchema(dto);
+
+
+        //Then
+        then(tableSchemaRepository).should().save(dto.createEntity());
+
+    }
+
+
 
 }


### PR DESCRIPTION
이 작업은 회원의 스키마 테이블 저장 기능을 구현한다.

This closes #30 