### PR TITLE
로직 구현: 스키마 데이터를 원하는 유형으로 변환하는 기능

### DIFF
--- a/src/main/java/org/leedae/testdata/domain/constant/ExportFileType.java
+++ b/src/main/java/org/leedae/testdata/domain/constant/ExportFileType.java
@@ -3,7 +3,10 @@ package org.leedae.testdata.domain.constant;
 import java.util.List;
 
 public enum ExportFileType   {
-    CSV,TSV,JSON,SQL_INSERT
+    CSV,
+    TSV,
+//    JSON,
+//    SQL_INSERT,
     ;
 
 }

--- a/src/main/java/org/leedae/testdata/service/SchemaExportService.java
+++ b/src/main/java/org/leedae/testdata/service/SchemaExportService.java
@@ -1,0 +1,27 @@
+package org.leedae.testdata.service;
+
+import lombok.RequiredArgsConstructor;
+import org.leedae.testdata.domain.TableSchema;
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.leedae.testdata.repository.TableSchemaRepository;
+import org.leedae.testdata.service.exporter.MockDataFileExporterContext;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SchemaExportService {
+
+    private final MockDataFileExporterContext mockDataFileExporterContext;
+    private final TableSchemaRepository tableSchemaRepository;
+
+    public String export(ExportFileType fileType, TableSchemaDto dto, Integer rowCount) {
+        if(dto.userId() != null){
+            tableSchemaRepository.findByUserIdAndSchemaName(dto.userId(),dto.schemaName())
+                    .ifPresent(TableSchema::markExported);
+
+        }
+        return mockDataFileExporterContext.export(fileType, dto, rowCount);
+    }
+
+}

--- a/src/main/java/org/leedae/testdata/service/exporter/CSVFileExporter.java
+++ b/src/main/java/org/leedae/testdata/service/exporter/CSVFileExporter.java
@@ -1,0 +1,54 @@
+package org.leedae.testdata.service.exporter;
+
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+public class CSVFileExporter extends DelimiterBasedFileExporter implements MockDataFileExporter{
+
+
+    @Override
+    public String getDelimiter() {
+        return ",";
+    }
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.CSV;
+    }
+
+    @Override
+    public String export(TableSchemaDto dto, Integer rowCount) {
+        StringBuilder sb = new StringBuilder();
+
+        // 헤더 만들기
+        sb.append(dto.schemaFields().stream()
+                        .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                .map(SchemaFieldDto::fieldName)
+                .collect(Collectors.joining(getDelimiter()))
+        );
+
+        sb.append("\n");
+
+        //데이터 부분
+        IntStream.range(0,rowCount).forEach(i -> {
+            sb.append(dto.schemaFields().stream()
+                    .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                    .map(field -> "가짜-데이터")
+                    .map(v -> v == null ? "" : v)
+                    .collect(Collectors.joining(getDelimiter()))
+
+            );
+            sb.append("\n");
+        });
+
+        return sb.toString();
+
+    }
+}

--- a/src/main/java/org/leedae/testdata/service/exporter/DelimiterBasedFileExporter.java
+++ b/src/main/java/org/leedae/testdata/service/exporter/DelimiterBasedFileExporter.java
@@ -1,0 +1,51 @@
+package org.leedae.testdata.service.exporter;
+
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+
+public abstract class DelimiterBasedFileExporter implements MockDataFileExporter{
+
+
+    /**
+     * 파일 열 구분자로 사용할 문자열을 반환한다.
+     *
+     * @return 파일 열 구분자
+     */
+    public abstract String getDelimiter();
+
+    @Override
+    public String export(TableSchemaDto dto, Integer rowCount) {
+        StringBuilder sb = new StringBuilder();
+
+        // 헤더 만들기
+        sb.append(dto.schemaFields().stream()
+                        .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                .map(SchemaFieldDto::fieldName)
+                .collect(Collectors.joining(getDelimiter()))
+        );
+
+        sb.append("\n");
+
+        //데이터 부분
+        IntStream.range(0,rowCount).forEach(i -> {
+            sb.append(dto.schemaFields().stream()
+                    .sorted(Comparator.comparing(SchemaFieldDto::fieldOrder))
+                    .map(field -> "가짜-데이터") //TODO: 구현할 것
+                    .map(v -> v == null ? "" : v)
+                    .collect(Collectors.joining(getDelimiter()))
+
+            );
+            sb.append("\n");
+        });
+
+        return sb.toString();
+
+    }
+}

--- a/src/main/java/org/leedae/testdata/service/exporter/MockDataFileExporter.java
+++ b/src/main/java/org/leedae/testdata/service/exporter/MockDataFileExporter.java
@@ -1,0 +1,26 @@
+package org.leedae.testdata.service.exporter;
+
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.TableSchemaDto;
+
+/**
+ * 특정 파일 유형 ({@link ExportFileType})에 맞는 데이터 출력 인터페이스.
+ */
+public interface MockDataFileExporter
+{
+
+    /**
+     * 구현체가 처리하는 출력 파일 유형을 반환하는 메소드.
+     *
+     * @return 이 구현체가 다루는 출력 파일 유형
+     */
+    ExportFileType getType();
+
+    /**
+     * 파일 형식에 맞는 문자열 데이터를 출력하는 메소드.
+     * @param dto 출력 데이터의 테이블 스키마 정보
+     * @param rowCount 출력할 데이터의 행 수
+     * @return 적절한 파일 형식으로 변환된 문자열 데이터
+     */
+    String export(TableSchemaDto dto, Integer rowCount);
+}

--- a/src/main/java/org/leedae/testdata/service/exporter/MockDataFileExporterContext.java
+++ b/src/main/java/org/leedae/testdata/service/exporter/MockDataFileExporterContext.java
@@ -1,0 +1,32 @@
+package org.leedae.testdata.service.exporter;
+
+
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class MockDataFileExporterContext {
+
+    private final Map<ExportFileType, MockDataFileExporter> mockDataFileExporterMap;
+
+    public MockDataFileExporterContext(List<MockDataFileExporter> mockDataFileExporters){
+        this.mockDataFileExporterMap = mockDataFileExporters.stream()
+                .collect(Collectors.toMap(MockDataFileExporter::getType, Function.identity()));
+
+    }
+
+    public String export(ExportFileType fileType, TableSchemaDto dto, Integer rowCount){
+        //원하는 구현체 (전략 패턴의 일종)
+        MockDataFileExporter fileExporter = mockDataFileExporterMap.get(fileType);
+
+        return fileExporter.export(dto, rowCount);
+
+    }
+
+}

--- a/src/main/java/org/leedae/testdata/service/exporter/TSVFileExporter.java
+++ b/src/main/java/org/leedae/testdata/service/exporter/TSVFileExporter.java
@@ -1,0 +1,27 @@
+package org.leedae.testdata.service.exporter;
+
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+public class TSVFileExporter extends DelimiterBasedFileExporter implements MockDataFileExporter{
+
+
+    @Override
+    public String getDelimiter() {
+        return "\t";
+    }
+
+    @Override
+    public ExportFileType getType() {
+        return ExportFileType.TSV;
+    }
+
+
+}

--- a/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
@@ -11,8 +11,10 @@ import org.leedae.testdata.dto.request.SchemaFieldRequest;
 import org.leedae.testdata.dto.request.TableSchemaExportRequest;
 import org.leedae.testdata.dto.request.TableSchemaRequest;
 import org.leedae.testdata.dto.security.GithubUser;
+import org.leedae.testdata.service.SchemaExportService;
 import org.leedae.testdata.service.TableSchemaService;
 import org.leedae.testdata.util.FormDataEncoder;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,15 +39,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(TableSchemaController.class)
 class TableSchemaControllerTest {
 
-    @Autowired
-    private MockMvc mvc;
-    @Autowired
-    private FormDataEncoder formDataEncoder;
-    @Autowired
-    private ObjectMapper mapper;
+    @Autowired private MockMvc mvc;
+    @Autowired private FormDataEncoder formDataEncoder;
+    @Autowired private ObjectMapper mapper;
 
-    @MockBean
-    private TableSchemaService tableSchemaService;
+    @MockBean private TableSchemaService tableSchemaService;
+    @MockBean private SchemaExportService schemaExportService;
 
     @DisplayName("[GET] 테이블 스키마 조회, 비로그인 최초 진입 (정상)")
     @Test
@@ -166,7 +165,7 @@ class TableSchemaControllerTest {
         then(tableSchemaService).should().deleteTableSchema(githubUser.id(), schemaName);
     }
 
-    @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상)")
+    @DisplayName("[GET] 테이블 스키마 파일 다운로드, 비로그인 (정상)")
     @Test
     void givenTableSchema_whenDownloading_thenReturnsFile() throws Exception {
         // Given
@@ -181,13 +180,47 @@ class TableSchemaControllerTest {
                 )
         );
         String queryParam = formDataEncoder.encode(request, false);
-
+        String expectedBody = "id,name,age\n1,lee,20";
+        given(schemaExportService.export(request.getFileType(),request.toDto(null),request.getRowCount()))
+                .willReturn(expectedBody);
         // When & Then
         mvc.perform(get("/table-schema/export?" + queryParam))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
                 .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=test.csv"))
-                .andExpect(content().json(mapper.writeValueAsString(request))); // TODO: 나중에 데이터 바꿔야 함
+                .andExpect(content().string(expectedBody));
+        then(schemaExportService).should().export(request.getFileType(),request.toDto(null),request.getRowCount());
+    }
+
+    @DisplayName("[GET] 테이블 스키마 파일 다운로드, 로그인 (정상)")
+    @Test
+    void givenAuthenticatedUserAndTableSchema_whenDownloading_thenReturnsFile() throws Exception {
+        // Given
+        var githubUser = new GithubUser("test-id", "test-name", "test-email");
+        TableSchemaExportRequest request = TableSchemaExportRequest.of(
+                "test",
+                77,
+                ExportFileType.CSV,
+                List.of(
+                        SchemaFieldRequest.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
+                        SchemaFieldRequest.of("name", MockDataType.STRING, 2, 0, "option", "well"),
+                        SchemaFieldRequest.of("age", MockDataType.NUMBER, 3, 20, null, null)
+                )
+        );
+        String queryParam = formDataEncoder.encode(request, false);
+        String expectedBody = "id,name,age\n1,lee,20";
+        given(schemaExportService.export(request.getFileType(),request.toDto(githubUser.id()),request.getRowCount()))
+                .willReturn(expectedBody);
+        // When & Then
+        mvc.perform(
+                get("/table-schema/export?" + queryParam)
+                        .with(oauth2Login().oauth2User(githubUser))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=test.csv"))
+                .andExpect(content().string(expectedBody));
+        then(schemaExportService).should().export(request.getFileType(),request.toDto(githubUser.id()),request.getRowCount());
     }
 
 }

--- a/src/test/java/org/leedae/testdata/service/SchemaExportServiceTest.java
+++ b/src/test/java/org/leedae/testdata/service/SchemaExportServiceTest.java
@@ -1,0 +1,76 @@
+package org.leedae.testdata.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.leedae.testdata.domain.TableSchema;
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.leedae.testdata.repository.TableSchemaRepository;
+import org.leedae.testdata.service.exporter.MockDataFileExporterContext;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@DisplayName("[Service] 스키마 파일 출력 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class SchemaExportServiceTest {
+
+    @InjectMocks SchemaExportService sut;
+    @Mock private MockDataFileExporterContext mockDataFileExporterContext;
+    @Mock private TableSchemaRepository tableSchemaRepository;
+
+    @DisplayName("출력 파일 유형과 스키마 정보와 행 수가 주어지면, 엔티티 출력 여부를 마킹하고 알맞은 파일 유형으로 가짜 데이터 파일을 반환한다.")
+    @Test
+    void givenFileTypeAndSchemaAndRowCount_whenExporting_thenMarksEntityExportedAndReturnsFileFormattedString(){
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of("test_schema", "lee", null, null);
+        int rowCount = 5;
+        TableSchema exectedTableSchema = TableSchema.of(dto.schemaName(),dto.userId());
+        given(tableSchemaRepository.findByUserIdAndSchemaName(dto.userId(),dto.schemaName())).willReturn(Optional.of(exectedTableSchema));
+        given(mockDataFileExporterContext.export(exportFileType,dto,rowCount)).willReturn("test,file,format");
+
+
+
+        // When
+        String result = sut.export(exportFileType,dto,rowCount);
+        // Then
+        assertThat(result).isEqualTo("test,file,format");
+        assertThat(exectedTableSchema.isExported()).isTrue();
+        then(tableSchemaRepository).should().findByUserIdAndSchemaName(dto.userId(),dto.schemaName());
+        then(mockDataFileExporterContext).should().export(exportFileType,dto,rowCount);
+
+    }
+
+    @DisplayName("입력 파라미터 중에 유저 식별 정보가 없으면, 스키마 테이블 조회를 시도하지 않는다.")
+    @Test
+    void givenNoUserIdInParams_whenExporting_thenDoesNotTrySelectingTableSchema(){
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of("test_schema", null, null, null);
+        int rowCount = 5;
+        TableSchema exectedTableSchema = TableSchema.of(dto.schemaName(),dto.userId());
+        given(mockDataFileExporterContext.export(exportFileType,dto,rowCount)).willReturn("test,file,format");
+
+
+        // When
+        String result = sut.export(exportFileType,dto,rowCount);
+
+        // Then
+        assertThat(result).isEqualTo("test,file,format");
+        then(tableSchemaRepository).shouldHaveNoInteractions();
+        then(mockDataFileExporterContext).should().export(exportFileType,dto,rowCount);
+
+    }
+
+
+}

--- a/src/test/java/org/leedae/testdata/service/exporter/CSVFileExporterTest.java
+++ b/src/test/java/org/leedae/testdata/service/exporter/CSVFileExporterTest.java
@@ -1,0 +1,50 @@
+package org.leedae.testdata.service.exporter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.domain.constant.MockDataType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Logic] CSV 파일 출력기 테스트")
+class CSVFileExporterTest {
+
+    private CSVFileExporter sut = new CSVFileExporter();
+
+
+    @DisplayName("테이블 스키마 정보와 행 수가 주어지면, CSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenSchemaAndRowCount_whenExporting_thenReturnsCSVFormattedString(){
+        // Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of(
+                "test_schema",
+                "lee",
+                null,
+                Set.of(
+                        SchemaFieldDto.of("id", MockDataType.ROW_NUMBER,1,0,null,null),
+                        SchemaFieldDto.of("name",MockDataType.NAME,2,0,null,null),
+                        SchemaFieldDto.of("created_at",MockDataType.DATETIME,5,0,null,null),
+                        SchemaFieldDto.of("age",MockDataType.NUMBER,3,0,null,null),
+                        SchemaFieldDto.of("car",MockDataType.CAR,4,0,null,null)
+                )
+
+        );
+        int rowCount = 10;
+
+        // When
+        String result = sut.export(dto,rowCount);
+
+        // Then
+        System.out.println(result);
+        assertThat(result).startsWith("id,name,age,car,created_at");
+    }
+
+
+}

--- a/src/test/java/org/leedae/testdata/service/exporter/MockDataFileExporterContextTest.java
+++ b/src/test/java/org/leedae/testdata/service/exporter/MockDataFileExporterContextTest.java
@@ -1,0 +1,55 @@
+package org.leedae.testdata.service.exporter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.domain.constant.MockDataType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DisplayName("[Integration] 파일 출력기 컨텍스트 테스트")
+@SpringBootTest
+record MockDataFileExporterContextTest(@Autowired MockDataFileExporterContext sut) {
+
+
+
+    @DisplayName("파일 형식과 테이블 스키마 행 수가 주어지면, 파일 형식에 맞게 변환한 문자열을 리턴한다.")
+    @Test
+    void givenFileTypeAndTableSchemaAndRowCount_whenExporting_thenReturnsFileFormattedString(){
+
+        //Given
+        ExportFileType exportFileType = ExportFileType.CSV;
+        TableSchemaDto dto = TableSchemaDto.of(
+                "test_schema",
+                "lee",
+                null,
+                Set.of(
+                        SchemaFieldDto.of("id", MockDataType.ROW_NUMBER,1,0,null,null),
+                        SchemaFieldDto.of("name",MockDataType.NAME,2,0,null,null),
+                        SchemaFieldDto.of("age", MockDataType.NUMBER,3,0,null,null),
+                        SchemaFieldDto.of("car",MockDataType.CAR,4,0,null,null),
+                        SchemaFieldDto.of("created_at", MockDataType.DATETIME,5,0,null,null)
+
+                )
+        );
+        int rowCount = 10;
+
+        //When
+        String result = sut.export(exportFileType,dto,rowCount);
+
+
+        //Then
+        System.out.println(result);
+        assertThat(result).startsWith("id,name,age,car,created_at");
+    }
+
+}

--- a/src/test/java/org/leedae/testdata/service/exporter/TSVFileExporterTest.java
+++ b/src/test/java/org/leedae/testdata/service/exporter/TSVFileExporterTest.java
@@ -1,0 +1,48 @@
+package org.leedae.testdata.service.exporter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.leedae.testdata.domain.constant.ExportFileType;
+import org.leedae.testdata.domain.constant.MockDataType;
+import org.leedae.testdata.dto.SchemaFieldDto;
+import org.leedae.testdata.dto.TableSchemaDto;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Logic] TSV 파일 출력기 테스트")
+class TSVFileExporterTest {
+
+    private TSVFileExporter sut = new TSVFileExporter();
+
+    @DisplayName("테이블 스키마 정보와 행 수가 주어지면, TSV 형식의 문자열을 생성한다.")
+    @Test
+    void givenSchemaAndRowCount_whenExporting_thenReturnsTSVFormattedString(){
+        // Given
+         ExportFileType exportFileType = ExportFileType.TSV;
+         TableSchemaDto dto = TableSchemaDto.of(
+                 "test_schema",
+                 "uno",
+                 null,
+                 Set.of(
+                         SchemaFieldDto.of("id", MockDataType.ROW_NUMBER,1,0,null,null),
+                         SchemaFieldDto.of("name",MockDataType.NAME,2,0,null,null),
+                         SchemaFieldDto.of("created_at",MockDataType.DATETIME,5,0,null,null),
+                         SchemaFieldDto.of("age",MockDataType.NUMBER,3,0,null,null),
+                         SchemaFieldDto.of("car", MockDataType.CAR,4,0,null,null)
+                 )
+
+         );
+         int rowCount = 10;
+
+        // When
+        String result = sut.export(dto,rowCount);
+
+
+         // Then
+         assertThat(result).startsWith("id\tname\tage\tcar\tcreated_at");
+    }
+
+}


### PR DESCRIPTION
이 작업은 스키마 데이터를 특정 형식의 파일 데이터로 변환하는 변환기들과 수용 구조를 전략 패턴, 팩토리 패턴을 참고하여 디자인한다.

This closes #33 