### PR TITLE
옵션 설정 UI 개선

### DIFF
--- a/src/main/resources/templates/table-schema.html
+++ b/src/main/resources/templates/table-schema.html
@@ -133,11 +133,12 @@
                   </div>
 
                   <!-- 옵션 -->
-                  <div class="md:w-1/4">
-                    <div class="relative">
-                      <input type="text" th:field="*{schemaFields[__${iterStat.index}__].typeOptionJson}" class="type-option-id type-option-name mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500" placeholder="{}">
-                      <i class="option-help fas fa-cog text-gray-500 hover:text-primary-600 cursor-pointer absolute right-3 top-1/2 transform -translate-y-1/2"></i>
-                    </div>
+                  <div class="md:w-1/4 flex gap-2">
+                    <input type="text" th:field="*{schemaFields[__${iterStat.index}__].typeOptionJson}" class="type-option-id type-option-name mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" placeholder="{}" readonly style="background-color: #f9fafb;">
+                    <button type="button" class="option-help mt-1 px-3 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 whitespace-nowrap text-sm flex items-center gap-1">
+                      <i class="fas fa-sliders-h"></i>
+                      <span class="hidden sm:inline">설정</span>
+                    </button>
                   </div>
 
                   <!-- 삭제 버튼 -->

--- a/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/org/leedae/testdata/controller/TableSchemaControllerTest.java
@@ -111,7 +111,7 @@ class TableSchemaControllerTest {
                                 .with(oauth2Login().oauth2User(githubUser))
                 )
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlTemplate("/table-schema?schemaName={schemaName}", request.getSchemaName()));
+                .andExpect(redirectedUrlTemplate("/table-schema?schemaName={schemaName}&saved=true", request.getSchemaName()));
         then(tableSchemaService).should().upsertTableSchema(request.toDto(githubUser.id()));
     }
 


### PR DESCRIPTION
## 개선 내용
필드 옵션 설정을 더 직관적으로 사용할 수 있도록 UI를 수정했습니다.

## 주요 변경사항
- 기존의 작은 톱니바퀴 아이콘을 명확한 '설정' 버튼으로 변경
- 옵션 입력란을 읽기 전용으로 만들어 사용자가 JSON을 직접 수정하지 않도록 유도
- 버튼 스타일을 primary 색상으로 통일해 다른 액션 버튼과 일관성 확보

## 개선 효과
- 옵션 설정 방법을 명확하게 안내
- JSON 문법을 모르는 사용자도 쉽게 사용 가능
- 실수로 잘못된 JSON을 입력하는 경우 방지

## 변경 파일
- table-schema.html
- TableSchemaControllerTest.java (리다이렉트 파라미터 업데이트)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make field options read-only with a new “설정” button and update POST redirect to append `saved=true`.
> 
> - **UI (table-schema)**:
>   - Replace inline gear icon with a dedicated "설정" button (`.option-help`) and make `typeOptionJson` input read-only with subdued background and smaller text.
>   - Adjust layout to a flex row with spacing (`md:w-1/4 flex gap-2`).
> - **Tests**:
>   - Update POST redirect expectation to include `&saved=true` in `/table-schema?schemaName={schemaName}&saved=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59c8672dfee195da9b780f9ed0d08e4b04ae4120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->